### PR TITLE
fix: retain rest or params

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ const Memo = React.memo(function Memo() {
 });
 ```
 
+### Babel Config
+
+```js
+{
+  plugins: [
+    ["babel-plugin-react-anonymous-display-name", {
+      "hocs": ['memo', 'forwardRef'], // optional
+    }]
+  ]
+}
+
+```
+
 ### Eslint plugin
 
 As you don't have to set `displayName` manually anymore, here is Eslint plugin that will help you to find places where you defined `displayName` on `memo()` components:

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,11 @@ const isNotNamed = (t: typeof babel.types, node: object) => {
     return !node.id;
   }
   return false;
-}
+};
 
-export default ({ types: t }: typeof babel): babel.PluginObj<{hocs?: string[]}> => ({
+export default ({
+  types: t
+}: typeof babel): babel.PluginObj<{ hocs?: string[] }> => ({
   visitor: {
     VariableDeclaration(path, state) {
       const hocs = state.hocs ?? SUPPORTED_HOCS;
@@ -39,32 +41,34 @@ export default ({ types: t }: typeof babel): babel.PluginObj<{hocs?: string[]}> 
 
       declarators.forEach((declarator) => {
         if (
-          t.isIdentifier(declarator.node.id) &&
-          t.isCallExpression(declarator.node.init) &&
-          isNotNamed(t, declarator.node.init.arguments[0]) &&
-          isAnonymousComponent(hocs)(t, declarator.node.init.callee)
+          !t.isIdentifier(declarator.node.id) ||
+          !t.isCallExpression(declarator.node.init)
         ) {
-          declarator.replaceWith(
-            t.variableDeclarator(
-              t.identifier(declarator.node.id.name),
-              t.callExpression(declarator.node.init.callee, [
-                t.functionExpression(
-                  t.identifier(declarator.node.id.name),
-                  declarator.node.init.arguments[0].params,
-                  // is memo((props) => { return *; }) case
-                  t.isBlockStatement(declarator.node.init.arguments[0].body)
-                    ? declarator.node.init.arguments[0].body
-                    : t.blockStatement([
-                        t.returnStatement(
-                          declarator.node.init.arguments[0].body
-                        )
-                      ])
-                ),
-                ...declarator.node.init.arguments.slice(1),
-              ])
-            )
-          );
+          return;
         }
+        const firstArgument = declarator.node.init.arguments[0] as any;
+        if (
+          !isNotNamed(t, firstArgument) ||
+          !isAnonymousComponent(hocs)(t, declarator.node.init.callee)
+        ) {
+          return;
+        }
+        declarator.replaceWith(
+          t.variableDeclarator(
+            t.identifier(declarator.node.id.name),
+            t.callExpression(declarator.node.init.callee, [
+              t.functionExpression(
+                t.identifier(declarator.node.id.name),
+                firstArgument.params,
+                // is memo((props) => { return *; }) case
+                t.isBlockStatement(firstArgument.body)
+                  ? firstArgument.body
+                  : t.blockStatement([t.returnStatement(firstArgument.body)])
+              ),
+              ...declarator.node.init.arguments.slice(1)
+            ])
+          )
+        );
       });
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,10 +34,10 @@ const isNamedAlready = (t: typeof babel.types, node: object) => {
 
 export default ({
   types: t
-}: typeof babel): babel.PluginObj<{ hocs?: string[] }> => ({
+}: typeof babel): babel.PluginObj<{opts: { hocs?: string[] }}> => ({
   visitor: {
     VariableDeclaration(path, state) {
-      const hocs = state.hocs ?? SUPPORTED_HOCS;
+      const hocs = state.opts.hocs ?? SUPPORTED_HOCS;
       const declarators = path.get('declarations');
 
       declarators.forEach((declarator) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,10 @@ import * as babel from '@babel/core';
 
 const SUPPORTED_HOCS = ['forwardRef', 'memo'];
 
-const isAnonymousComponent = (hocs: string[]) => (
+const isAnonymousComponent = (
   t: typeof babel.types,
-  callee: babel.types.Expression | babel.types.V8IntrinsicIdentifier
+  callee: babel.types.Expression | babel.types.V8IntrinsicIdentifier,
+  hocs: string[]
 ) => {
   if (t.isIdentifier(callee) && hocs.includes(callee.name)) {
     return true;
@@ -21,14 +22,14 @@ const isAnonymousComponent = (hocs: string[]) => (
   return false;
 };
 
-const isNotNamed = (t: typeof babel.types, node: object) => {
+const isNamedAlready = (t: typeof babel.types, node: object) => {
   if (t.isArrowFunctionExpression(node)) {
-    return true;
+    return false;
   }
   if (t.isFunctionExpression(node)) {
-    return !node.id;
+    return Boolean(node.id);
   }
-  return false;
+  return true;
 };
 
 export default ({
@@ -48,8 +49,8 @@ export default ({
         }
         const firstArgument = declarator.node.init.arguments[0] as any;
         if (
-          !isNotNamed(t, firstArgument) ||
-          !isAnonymousComponent(hocs)(t, declarator.node.init.callee)
+          isNamedAlready(t, firstArgument) ||
+          !isAnonymousComponent(t, declarator.node.init.callee, hocs)
         ) {
           return;
         }

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -14,7 +14,6 @@ function run(source: string, otherPlugins?: PluginItem[]) {
 }
 
 describe('supported HOC', () => {
-
   test('anonymous function', () => {
     const source = `
       const Hello4 = React.memo(function () { return null }, isEqual);
@@ -27,7 +26,7 @@ describe('supported HOC', () => {
         return null;
       }, isEqual);"
     `);
-  })
+  });
 
   test('anonymous arrow function', () => {
     const source = `
@@ -312,5 +311,24 @@ test('handle transform with react-refresh/babel', () => {
     $RefreshReg$(_c2, \\"Hello4\\");
     $RefreshReg$(_c3, \\"Hello5$memo\\");
     $RefreshReg$(_c4, \\"Hello5\\");"
+  `);
+});
+
+test('handle custom hocs', () => {
+  const source = `
+    const Hello4 = observer(() => null);
+  `;
+
+  const { code } = transform(source, {
+    filename: 'test.ts',
+    plugins: [[plugin, { hocs: ['observer'] }]]
+  })!;
+
+  expect(code).toMatchInlineSnapshot(`
+    "\\"use strict\\";
+
+    const Hello4 = observer(function Hello4() {
+      return null;
+    });"
   `);
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -14,9 +14,10 @@ function run(source: string, otherPlugins?: PluginItem[]) {
 }
 
 describe('supported HOC', () => {
-  test('anonymous arrow function', () => {
+
+  test('anonymous function', () => {
     const source = `
-      const Hello4 = React.memo(() => null);
+      const Hello4 = React.memo(function () { return null }, isEqual);
     `;
 
     expect(run(source)).toMatchInlineSnapshot(`
@@ -24,7 +25,21 @@ describe('supported HOC', () => {
 
       const Hello4 = React.memo(function Hello4() {
         return null;
-      });"
+      }, isEqual);"
+    `);
+  })
+
+  test('anonymous arrow function', () => {
+    const source = `
+      const Hello4 = React.memo(() => null, isEqual);
+    `;
+
+    expect(run(source)).toMatchInlineSnapshot(`
+      "\\"use strict\\";
+
+      const Hello4 = React.memo(function Hello4() {
+        return null;
+      }, isEqual);"
     `);
   });
 


### PR DESCRIPTION
* fix: retain rest or params (like memo's second param)
* Add option to config hocs directly in babel
* Add support for function () {} directly


credit goes to @bolasblack